### PR TITLE
WIP: Multiframework, tests and type overloads

### DIFF
--- a/src/MSDI.NamedServiceExtensions.sln
+++ b/src/MSDI.NamedServiceExtensions.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 15.0.28307.271
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSDI.NamedServiceExtensionsDemo", "MSDI.NamedServiceExtensionsDemo\MSDI.NamedServiceExtensionsDemo.csproj", "{8F2AF255-7D23-43A6-9EF9-DB21081750CB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSDI.NamedServiceExtensions", "MSDI.NamedServiceExtensions\MSDI.NamedServiceExtensions.csproj", "{C0A48F03-8043-4644-9317-22E8A35D613A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSDI.NamedServiceExtensions", "MSDI.NamedServiceExtensions\MSDI.NamedServiceExtensions.csproj", "{C0A48F03-8043-4644-9317-22E8A35D613A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSDI.NamedServiceExtensions.Tests", "..\test\MSDI.NamedServiceExtensions.Tests\MSDI.NamedServiceExtensions.Tests.csproj", "{8217F0E2-B73F-48A4-BE4F-C8DEDE013F40}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{C0A48F03-8043-4644-9317-22E8A35D613A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C0A48F03-8043-4644-9317-22E8A35D613A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0A48F03-8043-4644-9317-22E8A35D613A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8217F0E2-B73F-48A4-BE4F-C8DEDE013F40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8217F0E2-B73F-48A4-BE4F-C8DEDE013F40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8217F0E2-B73F-48A4-BE4F-C8DEDE013F40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8217F0E2-B73F-48A4-BE4F-C8DEDE013F40}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MSDI.NamedServiceExtensions/HashCode.cs
+++ b/src/MSDI.NamedServiceExtensions/HashCode.cs
@@ -1,0 +1,27 @@
+﻿#if NET472
+namespace MSDI.NamedServiceExtensions
+{
+    public static class HashCode
+    {
+        private const int MagicNumber = 397;
+
+        public static int Combine(params object[] parts)
+        {
+            unchecked
+            {
+                if (parts.Length == 0)
+                {
+                    return 0;
+                }
+
+                var hashCode = parts[0]?.GetHashCode() ?? 0;
+                for (var i = 1; i < parts.Length; i++)
+                    hashCode = (hashCode * MagicNumber) ^ (parts[i]?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+
+    }
+}
+#endif

--- a/src/MSDI.NamedServiceExtensions/MSDI.NamedServiceExtensions.csproj
+++ b/src/MSDI.NamedServiceExtensions/MSDI.NamedServiceExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/MSDI.NamedServiceExtensionsDemo/MSDI.NamedServiceExtensionsDemo.csproj
+++ b/src/MSDI.NamedServiceExtensionsDemo/MSDI.NamedServiceExtensionsDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/test/MSDI.NamedServiceExtensions.Tests/MSDI.NamedServiceExtensions.Tests.csproj
+++ b/test/MSDI.NamedServiceExtensions.Tests/MSDI.NamedServiceExtensions.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\MSDI.NamedServiceExtensionsDemo\Consumer.cs" Link="Consumer.cs" />
+    <Compile Include="..\..\src\MSDI.NamedServiceExtensionsDemo\Service.cs" Link="Service.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MSDI.NamedServiceExtensions\MSDI.NamedServiceExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/MSDI.NamedServiceExtensions.Tests/Named_Services.cs
+++ b/test/MSDI.NamedServiceExtensions.Tests/Named_Services.cs
@@ -27,21 +27,21 @@ namespace MSDI.NamedServiceExtensions.Tests
             Assert.That(resolved, Is.InstanceOf<ServiceA>());
         }
 
-        //[Test]
-        //public void Are_Resolved_Explicitly_From_Typed_Registration()
-        //{
-        //    services.AddNamedService(typeof(IService), typeof(ServiceA), "A name", ServiceLifetime.Transient);
-        //    var provider = services.BuildServiceProvider();
-        //    var resolved = provider.GetNamedService<IService>("A name");
-        //    Assert.That(resolved, Is.InstanceOf<ServiceA>());
-        //}
+        [Test]
+        public void Are_Resolved_Explicitly_From_Type_Registration()
+        {
+            services.AddNamedService(typeof(IService), typeof(ServiceA), "A name", ServiceLifetime.Transient);
+            var provider = services.BuildServiceProvider();
+            var resolved = provider.GetNamedService<IService>("A name");
+            Assert.That(resolved, Is.InstanceOf<ServiceA>());
+        }
 
         [Test]
         public void Are_Specified_For_Dependents()
         {
             services.AddNamedService<IService, ServiceA>("A name", ServiceLifetime.Transient);
 
-            RegisterResolveAndAssertConsumerCWithServiceA();
+            AssertConsumerWithNamedServiceA();
         }
 
         [Test]
@@ -50,10 +50,10 @@ namespace MSDI.NamedServiceExtensions.Tests
             services.AddNamedService<IService, ServiceA>("A name", ServiceLifetime.Transient);
             services.AddNamedService<IService, ServiceB>("Another name", ServiceLifetime.Transient);
 
-            RegisterResolveAndAssertConsumerCWithServiceA();
+            AssertConsumerWithNamedServiceA();
         }
 
-        private void RegisterResolveAndAssertConsumerCWithServiceA()
+        private void AssertConsumerWithNamedServiceA()
         {
             services.AddServiceWithNamedDependencies<IConsumerXY, ConsumerC>(
                 ServiceLifetime.Transient,

--- a/test/MSDI.NamedServiceExtensions.Tests/Named_Services.cs
+++ b/test/MSDI.NamedServiceExtensions.Tests/Named_Services.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace MSDI.NamedServiceExtensions.Tests
+{
+    [TestFixture]
+    public class Named_Services
+    {
+        private ServiceCollection services;
+
+        [SetUp]
+        public void Setup()
+        {
+            services = new ServiceCollection();
+
+            services.AddTransient(typeof(DateTime), _ => DateTime.Now);
+            services.AddTransient(typeof(TimeSpan), _ => TimeSpan.MaxValue);
+        }
+
+        [Test]
+        public void Are_Resolved_Explicitly_From_Generic_Registration()
+        {
+            services.AddNamedService<IService,ServiceA>("A name", ServiceLifetime.Transient);
+            var provider = services.BuildServiceProvider();
+            var resolved = provider.GetNamedService<IService>("A name");
+            Assert.That(resolved, Is.InstanceOf<ServiceA>());
+        }
+
+        //[Test]
+        //public void Are_Resolved_Explicitly_From_Typed_Registration()
+        //{
+        //    services.AddNamedService(typeof(IService), typeof(ServiceA), "A name", ServiceLifetime.Transient);
+        //    var provider = services.BuildServiceProvider();
+        //    var resolved = provider.GetNamedService<IService>("A name");
+        //    Assert.That(resolved, Is.InstanceOf<ServiceA>());
+        //}
+
+        [Test]
+        public void Are_Specified_For_Dependents()
+        {
+            services.AddNamedService<IService, ServiceA>("A name", ServiceLifetime.Transient);
+
+            RegisterResolveAndAssertConsumerCWithServiceA();
+        }
+
+        [Test]
+        public void Are_Specified_Amongst_Many_For_Dependents()
+        {
+            services.AddNamedService<IService, ServiceA>("A name", ServiceLifetime.Transient);
+            services.AddNamedService<IService, ServiceB>("Another name", ServiceLifetime.Transient);
+
+            RegisterResolveAndAssertConsumerCWithServiceA();
+        }
+
+        private void RegisterResolveAndAssertConsumerCWithServiceA()
+        {
+            services.AddServiceWithNamedDependencies<IConsumerXY, ConsumerC>(
+                ServiceLifetime.Transient,
+                new NamedDependency(typeof(IService), "A name", "service")
+            );
+
+            var provider = services.BuildServiceProvider();
+            var resolved = provider.GetService(typeof(IConsumerXY));
+            Assert.That(((ConsumerC) resolved).Service, Is.InstanceOf<ServiceA>());
+        }
+    }
+}


### PR DESCRIPTION
Just creating a PR for visibility of work related to #1.
Got the framework thing under control.
Barely got started with tests and had a go at type overloads for registration.
No refactoring or hard efforts yet. `HashCode` duped/centralized for net472 so should be easy to copy core code instead of reinventing the wheel.
